### PR TITLE
Fix show a max playercount of 1 instead of 20

### DIFF
--- a/main.js
+++ b/main.js
@@ -103,7 +103,7 @@ function startQueuing() {
 		host: '0.0.0.0',
 		port: config.ports.minecraft,
 		version: config.MCversion,
-		maxPlayers: 1
+		'max-players': maxPlayers = 1
 	});
 
 	server.on('login', (newProxyClient) => { // handle login


### PR DESCRIPTION
This still allows other players to join when the server is full for some reason, but it looks better.