### PR TITLE
Temporary security fix

### DIFF
--- a/main.js
+++ b/main.js
@@ -98,7 +98,7 @@ function startQueuing() {
 	});
 
 	server = mc.createServer({ // create a server for us to connect to
-		'online-mode': false,
+		'online-mode': true,
 		encryption: true,
 		host: '0.0.0.0',
 		port: config.ports.minecraft,
@@ -107,6 +107,9 @@ function startQueuing() {
 	});
 
 	server.on('login', (newProxyClient) => { // handle login
+		if(newProxyClient.username !== client.username){
+			stop();
+		}
 		newProxyClient.write('login', {
 			entityId: newProxyClient.id,
 			levelType: 'default',


### PR DESCRIPTION
This should not be merged, but is usable as a temporary fix for #18.

**I recommend using this temporary fix when running the server remotely and/or having the minecraft server port open in your router.**

To use this you have to relog in the launcher to regain a valid authentication token. It also shuts down the server whenever someone with the incorrect username joins (a.k.a stopping the queue). I know this is not optimal, but it is the only solution I could find that only took a couple seconds to write. (I don't have much time)