### PR TITLE
Prompt and save user credentials

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,16 +8,14 @@ A proxy to wait out 2b2t.org's way too long queue.
 2. Download this repository with the green button (top right of this page). If you downloaded it as zip, unzip it.
 3. Open a terminal and navigate to the folder you downloaded it in.
 4. Run `npm install`
-5. If you want to save your Minecraft login information in a file for automatic login, proceed to step 6. If not, ignore step 6 and proceed to step 7. However, you will need to re-enter your Minecraft login information into the console each time you start the program.
-6. Copy secrets.json.example and name it secrets.json. Fill out your Minecraft information in the file. Note that you must use your email address and not your Minecraft username.
-7. Copy config.json.example and name it config.json. Replace DISCORDBOT_FLAG and WEBSERVER_FLAG with true or false to your liking, then replace MINECRAFT_PROXY_PORT and WEB_UI_PORT with valid ports. Edit other values to your preference.
-8. For trust reasons, this tool does not update automatically. Check back here once in a while to see if there are any updates.
+5. Copy config.json.example and name it config.json. Replace DISCORDBOT_FLAG and WEBSERVER_FLAG with true or false to your liking, then replace MINECRAFT_PROXY_PORT and WEB_UI_PORT with valid ports. Edit other values to your preference.
+6. For trust reasons, this tool does not update automatically. Check back here once in a while to see if there are any updates.
 
 # How to use
 1. Read the code to ensure I'm not stealing your credentials. I'm not, but you shouldn't take my word for it. If you don't know how to read it, downloading stuff off the internet and giving it your password is probably a bad idea anyway.
 2. Run `npm start`
-3. If you created the secrets.json during the installation, you can ignore this or you have to enter your login data now.
-4. A browser window should open. You can close it if you want at any moment, and you can access it again at address http://localhost
+3. It will now ask for your Minecraft email and password. If you are using the discord bot you need to add your token. Then answer Y or N if you want to save your Minecraft email, password. If you answer N you will need to re-enter your Minecraft login information into the console each time you start the program.
+4. Now open a browser and navigate to http://localhost: your port here.
 5. Press the "Start queuing" button. The queue position indicator auto-updates, but sometimes it takes a while to start counting (like 1 min).
 6. After you log off, click the "stop queuing" button. This is really important, as you will not actually disconnect from 2b2t until you do that.
 

--- a/main.js
+++ b/main.js
@@ -11,6 +11,8 @@ const tokens = require('prismarine-tokens-fixed');
 const save = "./saveid";
 var mc_username;
 var mc_password;
+var discordBotToken;
+var savelogin;
 var secrets;
 var config;
 try {
@@ -29,19 +31,37 @@ try {
 	secrets = require('./secrets.json');
 	mc_username = secrets.username;
 	mc_password = secrets.password;
+  discordBotToken = secrets.BotToken
 	cmdInput();
 } catch {
 	config.discordBot = false;
 	if(config.minecraftserver.onlinemode) {
-		rl.question("Username: ", function(username) {
+    console.log("Please enter your credentials.");
+		rl.question("Email: ", function(username) {
 			rl.question("Password: ", function(userpassword) {
-				mc_username = username;
-				mc_password = userpassword;
-				console.clear();
-				cmdInput();
-			});
-		});
-	}
+        rl.question("BotToken, leave blank if not using discord: ", function(discordBotToken) {
+          rl.question("Save login for next use? Y or N:", function(savelogin) {
+    				mc_username = username;
+    				mc_password = userpassword;
+            if (savelogin === "Y" || savelogin === "y") {
+              if (discordBotToken === "") {
+                discordBotToken = "DiscordBotToken"
+              }
+              fs.writeFile('./secrets.json', `
+              {
+                  "username":"${username}",
+                  "password":"${userpassword}",
+                  "BotToken":"${discordBotToken}"
+              }`, function (err) {
+                if (err) return console.log(err);});
+            };
+    				console.clear();
+    				cmdInput();
+    			});
+    		});
+      });
+  	});
+  }
 }
 
 var stoppedByPlayer = false;
@@ -326,7 +346,7 @@ if (config.discordBot) {
 		}
 	});
 
-	dc.login(secrets.BotToken);
+	dc.login(discordBotToken);
 }
 
 function userInput(cmd, DiscordOrigin, discordMsg) {


### PR DESCRIPTION
To remove complexity just ask the user for email and password and save it the the json file. Making sure to ask the user if they want to save their credentials.

Things changed in this commit:
- Prompt user for email, password and bot token. Then if the user wants save them to a json.
- Move bot token to it’s own variable.
- Update readme to reflect changes.

Please make sure to test before merging. I have not tested the discord bot because I do not have it setup, everything else is tested.

Resolves #112 