### PR TITLE
Fix various typos, try a more accurate ETA calculation, changes to discord status

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -73,4 +73,3 @@ minecraft_token.json
 #config
 config.json
 
-docker-compose.yml

--- a/.gitignore
+++ b/.gitignore
@@ -70,3 +70,5 @@ saveid
 .project
 minecraft_token.json
 .eslintrc.js
+
+docker-compose.yml

--- a/config.json.example
+++ b/config.json.example
@@ -24,7 +24,7 @@
     "notification": { // sends a message via discord if the place in the queue reaches the specified number
         "enabled": true, // you must send the bot a message once.
         "queuePlace": 20
-    }
+    },
     "userStatus": true, // show username in discord bot status, in case of alts
     "antiAntiAFK": true, // to bypass antiAFK plugins
     "chunkCaching": true,

--- a/config.json.example
+++ b/config.json.example
@@ -23,7 +23,7 @@
     },
     "notification": { // sends a message via discord if the place in the queue reaches the specified number
         "enabled": true, // you must send the bot a message once.
-        "queuePlace": 20
+        "queuePlace": 20,
         "userStatus": true // show username in discord bot status, in case of alts
     },
     "antiAntiAFK": true, // to bypass antiAFK plugins

--- a/config.json.example
+++ b/config.json.example
@@ -23,9 +23,9 @@
     },
     "notification": { // sends a message via discord if the place in the queue reaches the specified number
         "enabled": true, // you must send the bot a message once.
-        "queuePlace": 20,
-        "userStatus": true // show username in discord bot status, in case of alts
-    },
+        "queuePlace": 20
+    }
+    "userStatus": true, // show username in discord bot status, in case of alts
     "antiAntiAFK": true, // to bypass antiAFK plugins
     "chunkCaching": true,
     "joinOnStart": false // join the server when 2b2w is started

--- a/config.json.example
+++ b/config.json.example
@@ -24,6 +24,7 @@
     "notification": { // sends a message via discord if the place in the queue reaches the specified number
         "enabled": true, // you must send the bot a message once.
         "queuePlace": 20
+        "userStatus": true // show username in discord bot status, in case of alts
     },
     "antiAntiAFK": true, // to bypass antiAFK plugins
     "chunkCaching": true

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,6 +2,7 @@
 version: "3"
 services:
    2bored2wait:
+      build: .
       image: dsetareh/2bored2wait:latest
       container_name: 2bored2wait
       stdin_open: true

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,6 @@
 version: "3"
 services:
    2bored2wait:
-      build: .
       image: dsetareh/2bored2wait:latest
       container_name: 2bored2wait
       stdin_open: true

--- a/main.js
+++ b/main.js
@@ -148,7 +148,11 @@ function join() {
 						ETAhour = totalWaitTime - timepassed;
 						webserver.ETA = Math.floor(ETAhour) + "h " + Math.round((ETAhour % 1) * 60) + "m";
 						server.motd = `Place in queue: ${positioninqueue} ETA: ${webserver.ETA}`; // set the MOTD because why not
-						logActivity("Pos: " + webserver.queuePlace + " ETA: " + webserver.ETA); //set the Discord Activity
+						if (config.notification.userStatus === true) { //set the Discord Activity
+							logActivity("P: " + webserver.queuePlace + " E: " + webserver.ETA + " - " + options.username);
+						} else {
+							logActivity("P: " + webserver.queuePlace + " E: " + webserver.ETA);
+						}
 						if (config.notification.enabled && webserver.queuePlace <= config.notification.queuePlace && !notisend && config.discordBot && dcUser != null) {
 								sendDiscordMsg(dcUser, "Queue", "The queue is almost finished. You are in Position: " + webserver.queuePlace);
 							notisend = true;
@@ -371,7 +375,7 @@ function userInput(cmd, DiscordOrigin, discordMsg) {
 					break;
 				case "calcTime":
 					let calcMsg = 
-					msg(DiscordOrigin, discordMsg, "Calculating time", "Calculating the time, so you can paly at " + starttimestring);
+					msg(DiscordOrigin, discordMsg, "Calculating time", "Calculating the time, so you can play at " + starttimestring);
 					break;
 			}
 			break;

--- a/main.js
+++ b/main.js
@@ -423,6 +423,7 @@ function userInput(cmd, DiscordOrigin, discordMsg) {
 
 function stopMsg(discordOrigin, discordMsg, stoppedThing) {
 	msg(discordOrigin, discordMsg, stoppedThing, stoppedThing + " is **stopped**");
+	dc.user.setActivity(stoppedThing + " is stopped.");
 }
 
 function msg(discordOrigin, msg, titel, content) {

--- a/main.js
+++ b/main.js
@@ -142,11 +142,13 @@ function join() {
 					webserver.queuePlace = positioninqueue; // update info on the web page
 					if (webserver.queuePlace !== "None" && lastQueuePlace !== webserver.queuePlace) {
 						if (!totalWaitTime) {
-							totalWaitTime = Math.pow(positioninqueue / 35.4, 2 / 3);
+							// totalWaitTime = Math.pow(positioninqueue / 35.4, 2 / 3); // disabled for testing corrected ETA
+							totalWaitTime = positioninqueue / 2;
 						}
-						timepassed = -Math.pow(positioninqueue / 35.4, 2 / 3) + totalWaitTime;
+						// timepassed = -Math.pow(positioninqueue / 35.4, 2 / 3) + totalWaitTime; //disabled for testing corrected ETA
+						timepassed = -(positioninqueue / 2) + totalWaitTime;
 						ETAhour = totalWaitTime - timepassed;
-						webserver.ETA = Math.floor(ETAhour) + "h " + Math.round((ETAhour % 1) * 60) + "m";
+						webserver.ETA = Math.floor(ETAhour / 60) + "h " + Math.round(ETAhour % 60) + "m";
 						server.motd = `Place in queue: ${positioninqueue} ETA: ${webserver.ETA}`; // set the MOTD because why not
 						if (config.notification.userStatus === true) { //set the Discord Activity
 							logActivity("P: " + webserver.queuePlace + " E: " + webserver.ETA + " - " + options.username);
@@ -469,7 +471,8 @@ function calcTime(msg) {
 			});
 			resp.on("end", () => {
 				data = JSON.parse(data);
-				totalWaitTime = Math.pow(data[0][1] / 35.4, 2 / 3); // data[0][1] is the current queue length
+				// totalWaitTime = Math.pow(data[0][1] / 35.4, 2 / 3); // data[0][1] is the current queue length
+				totalWaitTime = data[0][1] / 2;
 				playTime = timeStringtoDateTime(msg);
 				if (playTime.toSeconds() - DateTime.local().toSeconds() < totalWaitTime * 3600) {
 					startQueuing();

--- a/main.js
+++ b/main.js
@@ -18,7 +18,7 @@ var config;
 try {
   config = JSON.parse(jsonminify(fs.readFileSync("./config.json", "utf8"))); // Read the config
 } catch (err) {
-  console.log("No config file, Please create one."); // If no config exsists
+  console.log("No config file, Please create one."); // If no config exists
 	process.exit()
 }
 let finishedQueue = !config.minecraftserver.is2b2t;
@@ -179,7 +179,7 @@ function join() {
 						ETAhour = totalWaitTime - timepassed;
 						server.motd = `Place in queue: ${webserver.queuePlace} ETA: ${webserver.ETA}`; // set the MOTD because why not
 						webserver.ETA = Math.floor(ETAhour / 60) + "h " + Math.floor(ETAhour % 60) + "m";
-						if (config.notification.userStatus === true) { //set the Discord Activity
+						if (config.userStatus === true) { //set the Discord Activity
 							logActivity("P: " + webserver.queuePlace + " E: " + webserver.ETA + " - " + options.username);
 						} else {
 							logActivity("P: " + webserver.queuePlace + " E: " + webserver.ETA);
@@ -452,7 +452,7 @@ function userInput(cmd, DiscordOrigin, discordMsg) {
 
 function stopMsg(discordOrigin, discordMsg, stoppedThing) {
 	msg(discordOrigin, discordMsg, stoppedThing, stoppedThing + " is **stopped**");
-	dc.user.setActivity(stoppedThing + " is stopped.");
+	activity(stoppedThing + " is stopped.");
 }
 
 function msg(discordOrigin, msg, title, content) {

--- a/main.js
+++ b/main.js
@@ -148,7 +148,7 @@ function join() {
 						// timepassed = -Math.pow(positioninqueue / 35.4, 2 / 3) + totalWaitTime; //disabled for testing corrected ETA
 						timepassed = -(positioninqueue / 2) + totalWaitTime;
 						ETAhour = totalWaitTime - timepassed;
-						webserver.ETA = Math.floor(ETAhour / 60) + "h " + Math.round(ETAhour % 60) + "m";
+						webserver.ETA = Math.floor(ETAhour / 60) + "h " + Math.floor(ETAhour % 60) + "m";
 						server.motd = `Place in queue: ${positioninqueue} ETA: ${webserver.ETA}`; // set the MOTD because why not
 						if (config.notification.userStatus === true) { //set the Discord Activity
 							logActivity("P: " + webserver.queuePlace + " E: " + webserver.ETA + " - " + options.username);
@@ -426,12 +426,12 @@ function stopMsg(discordOrigin, discordMsg, stoppedThing) {
 	dc.user.setActivity(stoppedThing + " is stopped.");
 }
 
-function msg(discordOrigin, msg, titel, content) {
-	if(discordOrigin) sendDiscordMsg(msg.channel, titel, content);
+function msg(discordOrigin, msg, title, content) {
+	if(discordOrigin) sendDiscordMsg(msg.channel, title, content);
 	else console.log(content);
 }
 
-function sendDiscordMsg(channel, titel, content) {
+function sendDiscordMsg(channel, title, content) {
 	channel.send({
 		embed: {
 			color: 3447003,
@@ -440,7 +440,7 @@ function sendDiscordMsg(channel, titel, content) {
 				icon_url: dc.user.avatarURL
 			},
 			fields: [{
-				name: titel,
+				name: title,
 				value: content
 			}
 			],

--- a/replace_config.sh
+++ b/replace_config.sh
@@ -4,6 +4,10 @@
 
 # script used to set the config values in the docker image
 
+# if file already exists it means it has been mounted, I'll use that one
+
+if [ ! -f /srv/app/config.json ]; then
+
 # create config file
 cp config.json.example config.json
 
@@ -12,3 +16,5 @@ sed -i 's/DISCORDBOT_FLAG/'"$DISCORD_BOT"'/g' config.json
 sed -i 's/WEBSERVER_FLAG/'"$WEBSERVER"'/g' config.json
 sed -i 's/MINECRAFT_PROXY_PORT/'"$MINECRAFT_PORT"'/g' config.json
 sed -i 's/WEB_UI_PORT/'"$WEBUI_PORT"'/g' config.json
+
+fi


### PR DESCRIPTION
1.) Fixed a couple of typos.

2.) Existing ETA calculation tended to be over an hour longer than 2b2t's actual estimated wait time, causing the scheduling function to mis-time joining. Changed the ETA calculation to something more accurate, typically within 10-15 minute delta from actual estimate from server.

3.) Added an option to show which username (account) is currently in the queue, so the user knows which account to connect to the proxy server with, in case they use alts.

4.) Discord bot status wouldn't always update when stopping queue, fixed to make sure it always updates.

You can ignore the commits mentioning changes to .gitignore and docker-compose.yml, they were just changes so that the image would build locally every time I loaded it in WebStorm. I reverted the changes before creating this pull request.