### PR TITLE
whitelist

### DIFF
--- a/config.json.example
+++ b/config.json.example
@@ -28,5 +28,6 @@
     "userStatus": true, // show username in discord bot status, in case of alts
     "antiAntiAFK": true, // to bypass antiAFK plugins
     "chunkCaching": true,
-    "joinOnStart": false // join the server when 2b2w is started
+    "joinOnStart": false, // join the server when 2b2w is started
+    "whitelist": false // only let the same minecraft account join 2b2w as the one connected to 2b2t
 }

--- a/main.js
+++ b/main.js
@@ -249,7 +249,7 @@ function join() {
 	});
 
 	server = mc.createServer({ // create a server for us to connect to
-		'online-mode': false,
+		'online-mode': config.whitelist,
 		encryption: true,
 		host: '0.0.0.0',
 		port: config.ports.minecraft,
@@ -258,6 +258,10 @@ function join() {
 	});
 
 	server.on('login', (newProxyClient) => { // handle login
+		if(config.whitelist && client.uuid !== newProxyClient.uuid) {
+			newProxyClient.end("not whitelisted!\nYou need to use the same account as 2b2w or turn the whitelist off");
+			return;
+		}
 		setTimeout(sendChunks, 1000)
 		newProxyClient.write('login', loginpacket);
 		newProxyClient.write('position', {


### PR DESCRIPTION
- sets 2b2w onlinemode to true
- only let the same minecraft account join 2b2w as the one connected to 2b2t
- fixed #18 and inspired by #20