### PR TITLE
Reworked initial setup process, added auth using launcher data, bumped mc-proto

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ A proxy to wait out 2b2t.org's way too long queue.
 # How to use
 1. Read the code to ensure I'm not stealing your credentials. I'm not, but you shouldn't take my word for it. If you don't know how to read it, downloading stuff off the internet and giving it your password is probably a bad idea anyway.
 2. Run `npm start`
-3. It will now ask for your Minecraft email and password. If you are using the discord bot you need to add your token. Then answer Y or N if you want to save your Minecraft email, password. If you answer N you will need to re-enter your Minecraft login information into the console each time you start the program.
+3. It will now ask for your Minecraft email and password (or permission to use saved launcher data instead). If you are using the discord bot you need to add your token. Then answer Y or N if you want to save your Minecraft credentials. If you answer N you will need to re-enter your Minecraft login information into the console each time you start the program.
 4. Now open a browser and navigate to http://localhost: your port here.
 5. Press the "Start queuing" button. The queue position indicator auto-updates, but sometimes it takes a while to start counting (like 1 min).
 6. Once the queue reaches a low number, connect to the Minecraft server at address `localhost`.

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "everpolate": "0.0.3",
     "luxon": "^1.26.0",
     "mcproxy": "git+https://github.com/MrGeorgen/mcproxy.git#2b2w",
-    "minecraft-protocol": "^1.23.1",
+    "minecraft-protocol": "^1.24.1",
     "node-json-minify": "^1.0.0",
     "open": "^6.0.0",
     "particles.js": "^2.0.0"


### PR DESCRIPTION
This will allow users to use auth info stored by Minecraft Launcher instead of typing their email and password and (optionally) saving all of that in plaintext
Might also help with #225