### PR TITLE
(Quickfix) Fix Address already assigned(Issue #338) bug when reconnecting.

### DIFF
--- a/main.js
+++ b/main.js
@@ -81,7 +81,7 @@ const askForSecrets = async () => {
 	localConf.discordBot = discordBotToken === "" ? false : config.has("discordBot") && config.get("discordBot");
 
 	if(canSave) {
-		
+
 		savelogin = await promisedQuestion("Save login for later use? Y or N [N]: ");
 		if (savelogin.toLowerCase() === "y") {
 			fs.writeFile('config/local.json', JSON.stringify(localConf, null, 2), (err) => {
@@ -187,15 +187,20 @@ function stop() {
 	finishedQueue = !config.minecraftserver.is2b2t;
 	webserver.queuePlace = "None";
 	webserver.ETA = "None";
-	client.end(); // disconnect
+	if(client){
+		client.end(); // disconnect
+	}
 	if (proxyClient) {
 		proxyClient.end("Stopped the proxy."); // boot the player from the server
 	}
-	server.close(); // close the server
+	if(server){
+		server.close(); // close the server
+	}
 }
 
 // function to start the whole thing
 function startQueuing() {
+	stopQueing();
 	doing = "auth";
 	if (config.get("minecraftserver.onlinemode")) {
 		options.username = mc_username;
@@ -226,7 +231,7 @@ function join() {
 				if (!finishedQueue && config.minecraftserver.is2b2t) { // if the packet contains the player list, we can use it to see our place in the queue
 					let headermessage = JSON.parse(data.header);
                                         let positioninqueue = "None";
-                                        try{	
+                                        try{
                                             positioninqueue = headermessage.text.split("\n")[5].substring(25);
 				        }catch(e){
                                             if (e instanceof TypeError)
@@ -383,17 +388,17 @@ function activity(string) {
 
 function userInput(cmd, DiscordOrigin, discordMsg) {
 	 cmd = cmd.toLowerCase();
-	
+
 	switch (cmd) {
 		case "start":
 			startQueuing();
 			msg(DiscordOrigin, discordMsg, "Queue", "Queue is starting up");
 			break;
-		
+
 		case "exit":
 		case "quit":
 			return process.exit(0);
-			
+
 		case "update":
 			switch (doing) {
 				case "queue":
@@ -435,7 +440,7 @@ function userInput(cmd, DiscordOrigin, discordMsg) {
 					msg(DiscordOrigin, discordMsg, authMsg, authMsg);
 					break;
 				case "calcTime":
-					let calcMsg = 
+					let calcMsg =
 						msg(DiscordOrigin, discordMsg, "Calculating time", "Calculating the time, so you can play at " + starttimestring);
 					break;
 			}


### PR DESCRIPTION
This is the quick bugfix of [this issue](https://github.com/themoonisacheese/2bored2wait/issues/338), As you can see the current version will give exception when reconnecting to 2b2t, as well if you try to start server twice without stopping it (like give **start** command, then before stopping it give another **start** command).

This is a quickfix, i only added a call to _stopQueing()_ in the start of _startQueuing()_ so the proxy always close existent resources before starting to queue.

To Reproduce This Bug:
1. Start 2b2t console client _npm start_ and start Queing _start_
2. Turn off your internet/wifi connection for something like 5-10 secs (might need more than that idk) then turn on again.
3. See the console, it will try to reconnect and then throw an Exception with error message _address already in use 0.0.0.0:25565_