### PR TITLE
(Quickfix) Update main.js to enable saving of account type(Microsoft or mojang) to configs.

### DIFF
--- a/main.js
+++ b/main.js
@@ -60,6 +60,7 @@ const askForSecrets = async () => {
 			accountType = ((await promisedQuestion("Account type, mojang (1) or microsoft (2) [1]: ")) === "2" ? "microsoft" : "mojang");
 			mc_username = await promisedQuestion("Email: ");
 			mc_password = await promisedQuestion("Password: ");
+			localConf.accountType = accountType;
 			localConf.mcPassword = mc_password;
 			updatemessage = await promisedQuestion("Update Messages? Y or N [Y]: ");
 			localConf.updatemessage = updatemessage;


### PR DESCRIPTION
Bugfix: Earlier 2b2w wasn't saving account type to the configs on first launch (When it was asking different kind of info to user). So I, and maybe many other user's were having problem where when they selected account type to be Microsoft (By inputting 2), they weren't getting any effect of it, So the queue was not working (In case of microsoft accounts)!!

I got this problem fixed for myself by manually  changing mojang to microsoft in config/default.json!! but that might not be case for many other's who might be clueless why they couldn't queue using microsoft account. (So here's your PR)