### PR TITLE
Fix getting position in queue

### DIFF
--- a/main.js
+++ b/main.js
@@ -234,7 +234,7 @@ function join() {
 					let messageheader = data.header;
 					let positioninqueue = "None";
 					try {
-						positioninqueue = messageheader.split('text')[5].replace(/\D/g, '');
+						positioninqueue = JSON.parse(messageheader)['extra'][2]['extra'][0]['text'].replace(/\D/g, '');
 					} catch (e) {
 						if (e instanceof TypeError && (PositionError !== true)) {
 							console.log("Reading position in queue from tab failed! Is the queue empty, or the server isn't 2b2t?");


### PR DESCRIPTION
This patch fixes the queue position fetching logic to work with 2b2t's updated tab list.

Fixes #543