### PR TITLE
Remove comments from config/default.json in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,6 +12,9 @@ COPY . "/srv/app"
 # install requirements
 RUN npm install
 
+# remove comments from config/default.json
+RUN sed -i 's/\/\/.*$//' config/defaulr.json
+
 # exposing 8080 (webui), 25566 (mc proxy)
 EXPOSE 8080/tcp
 EXPOSE 25565/tcp


### PR DESCRIPTION
The comments in `config/default.json` causes npm to fail. When building the Docker container, them should be removed. Instad of editing the file in the source code, it can be removed with `sed` in `Dockerfile`. Using aditional RUN to keep the `npm install` command cached.